### PR TITLE
Add "set -ex" for stopping the setup scripts on failing commands, chmod +x all the setup scripts, and comment out upstream test suites that we don't actually need to run

### DIFF
--- a/go-sdl2/run.bash
+++ b/go-sdl2/run.bash
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -ex
+
+gb vendor -v restore
+gb build

--- a/go-sdl2/setup.bash
+++ b/go-sdl2/setup.bash
@@ -1,3 +1,4 @@
 #!/bin/bash
+set -ex
 
 sudo apt-get install make pkg-config libsdl2{,-mixer,-image,-ttf}-dev -y

--- a/goczmq/run.bash
+++ b/goczmq/run.bash
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -ex
+
+gb vendor -v restore
+gb build

--- a/goczmq/setup.bash
+++ b/goczmq/setup.bash
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -ex
 
 # setup steps taken from https://github.com/zeromq/goczmq
 
@@ -11,7 +12,7 @@ gpg --import jedi.gpg.asc
 gpg --verify libsodium-1.0.3.tar.gz.sig libsodium-1.0.3.tar.gz
 tar zxvf libsodium-1.0.3.tar.gz
 pushd libsodium-1.0.3
-./configure; make check
+./configure; #make check
 sudo make install
 sudo ldconfig
 popd
@@ -19,7 +20,7 @@ popd
 wget http://download.zeromq.org/zeromq-4.1.1.tar.gz
 tar zxvf zeromq-4.1.1.tar.gz
 pushd zeromq-4.1.1
-./configure --with-libsodium; make; make check
+./configure --with-libsodium; make; #make check
 sudo make install
 sudo ldconfig
 popd
@@ -27,7 +28,7 @@ popd
 wget http://download.zeromq.org/czmq-3.0.1.tar.gz
 tar zxvf czmq-3.0.1.tar.gz
 pushd czmq-3.0.1
-./configure; make check
+./configure; #make check
 sudo make install
 sudo ldconfig
 popd

--- a/service.v1/run.bash
+++ b/service.v1/run.bash
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -ex
+
+mkdir -p src
+gb vendor -v restore
+cd vendor
+gb build
+gb test

--- a/service.v1/setup.bash
+++ b/service.v1/setup.bash
@@ -1,3 +1,4 @@
 #!/bin/bash
+set -ex
 
 sudo apt-get install libcap-dev -y

--- a/sqlite3/run.bash
+++ b/sqlite3/run.bash
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -ex
+
+gb vendor -v restore
+gb build

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,0 +1,20 @@
+box: golang:1.4
+build:
+  steps:
+    - script:
+        name: install gb
+        code: |
+          go get -v github.com/constabulary/gb/...
+
+    - install-packages:
+        packages: sudo
+
+    - script:
+        name: integration tests
+        code: |
+          for script in */run.bash; do
+            pushd "$(dirname "$script")"
+            [ -x setup.bash ] && ./setup.bash
+            ./run.bash
+            popd
+          done


### PR DESCRIPTION
Happy to split this up into multiple commits if you'd prefer (or to rebase/amend as desired). :+1:

My end goal is to move as much of the logic out of `wercker.yml` and into these scripts as possible (which seems like it's been your goal too, hence why I'm pursuing it).

It's a little bit tempting to also add a `run.bash` for each of these so that we could simplify the `wercker.yml` blocks down to just one simple block like:

``` yaml
    - script:
        name: integration tests
        code: |
          git clone --quiet https://github.com/constabulary/integration-tests.git
          for script in integration-tests/*/run.bash; do
            pushd "$(dirname "$script")"
            [ -x setup.bash ] && ./setup.bash
            ./run.bash
            popd
          done
```

(Which would make it trivial to run these tests locally or add new tests.)

If we structure that way, then we could also setup `wercker.yml` here so that we make sure all commits here build and work properly without having to go kick the `gb` build directly.

Proof that this PR works!  https://app.wercker.com/#build/55fa5f92e61ac3b508215893 :metal: (https://github.com/tianon/gb/commit/0d73ce35c9aa5450ae847bd4f1bd8a1cb240dde5)
