### PR TITLE
Add "wercker status" badge/graph to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # integration-tests
+
+[![wercker status](https://app.wercker.com/status/196383b97bc168997f5252b51a80af0c/m/master "wercker status")](https://app.wercker.com/project/bykey/196383b97bc168997f5252b51a80af0c)


### PR DESCRIPTION
I used the version that's limited to just showing `master` statuses -- not sure if you'd rather see failing PRs on the README graph also, but happy to adjust. :+1:
